### PR TITLE
explicitly specify the local timezone

### DIFF
--- a/python/evet/cli.py
+++ b/python/evet/cli.py
@@ -26,6 +26,12 @@ logger = get_logger()
     type=click.DateTime(formats=["%Y-%m-%d %H:%M"]),
 )
 @click.option(
+    "-l",
+    "--local",
+    help="Specify the base timezone for the event.",
+    type=str,
+)
+@click.option(
     "-t",
     "--timezone",
     help="Specify the timezone for adding event date by timezone.",
@@ -41,12 +47,13 @@ logger = get_logger()
 async def cli(
     message: str,
     date: datetime.datetime,
+    local: str,
     timezone: t.Tuple[str],
     verbose: int,
 ) -> None:
     set_log_level(verbosity=verbose)
 
-    event_date = EventDate(date=date, timezones=timezone)
+    event_date = EventDate(date=date, local=local, timezones=timezone)
     logger.debug(
         "current timezone: %s - %s",
         event_date.get_local_zone(),

--- a/python/evet/date.py
+++ b/python/evet/date.py
@@ -1,4 +1,6 @@
 import datetime
+import os
+import time
 import typing as t
 
 import pytz
@@ -8,9 +10,15 @@ from tzlocal import get_localzone
 class EventDate(object):
     def __init__(
         self,
+        local: str,
         date: datetime.datetime,
         timezones: t.Tuple[str],
     ) -> None:
+
+        if local:
+            os.environ["TZ"] = local
+            time.tzset()
+
         self.__date = date
         self.__local_zone = get_localzone()
         self.__timezones = timezones


### PR DESCRIPTION
`[only python]`
In addition to standard arguments the local timezone can be explicitly specified like `--local=<timezone>`

The given example in the README file is based on the current timezone. With the `local` argument, user can specify the willing timezone. 

My local timezone is `Europe/Istanbul` but I can get the same output with specify the timezone by `local` argument.
```sh
evet --message="Rust Berlin Talks" \
     --date="2021-11-23 23:00" \
     --timezone="Europe/Istanbul" \
     --timezone="Europe/Berlin" \
     --timezone="Japan" \
     --local="Europe/Berlin"

---
Rust Berlin Talks

Istanbul: 2021-11-24 01:00
Berlin: 2021-11-23 23:00
Japan: 2021-11-24 07:00
---
```